### PR TITLE
Allow falsy values to be stored as long as they're defined

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -25,11 +25,14 @@ export type StorageProxy<TStorageDefinitions> = Partial<TStorageDefinitions> & {
 // --- Utilities ------------------------------------------------------------ //
 
 /**
- * Determines if the passed value is defined
- * @param value The value to check
+ * Checks if the passed value is undefined.
+ *
+ * @param value - The value to check.
+ *
+ * @return Returns true if value is undefined, else false.
  */
-export function isDefined<T>(value: T | undefined | null): value is T {
-  return <T> value !== undefined && <T> value !== null;
+export function isUndefined(value: any): value is undefined {
+  return value === undefined;
 }
 
 /**
@@ -95,7 +98,7 @@ function createProxy<TStorageDefinitions extends any>(
 
   if (defaults) {
     for (const [key, value] of Object.entries(defaults)) {
-      if (!isDefined(data[key])) {
+      if (isUndefined(data[key])) {
         storageProxy[key] = value;
       }
     }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -25,6 +25,14 @@ export type StorageProxy<TStorageDefinitions> = Partial<TStorageDefinitions> & {
 // --- Utilities ------------------------------------------------------------ //
 
 /**
+ * Determines if the passed value is defined
+ * @param value The value to check
+ */
+export function isDefined<T>(value: T | undefined | null): value is T {
+  return <T> value !== undefined && <T> value !== null;
+}
+
+/**
  * Initializes the web storage interface. If no storage exists, we save an empty
  * object.
  *
@@ -73,13 +81,13 @@ function createProxy<TStorageDefinitions extends any>(
     [isStorageProxy]: true,
     [storageTargetSymbol]: storageTarget,
   };
-  const proxyData = onChange(data, (path, value, prevValue) => {
+  const proxyData = onChange(data, (_path, value, prevValue) => {
     if (value === prevValue) return;
     window[storageTarget].setItem(namespace, JSON.stringify(proxyData));
   });
 
   const storageProxy = new Proxy(proxyData, {
-    get: (target, prop, receiver) => {
+    get: (_target, prop, _receiver) => {
       if (typeof proxyData[prop as any] === 'undefined') return null;
       return proxyData[prop as any];
     },
@@ -87,7 +95,7 @@ function createProxy<TStorageDefinitions extends any>(
 
   if (defaults) {
     for (const [key, value] of Object.entries(defaults)) {
-      if (!data[key]) {
+      if (!isDefined(data[key])) {
         storageProxy[key] = value;
       }
     }


### PR DESCRIPTION
Currently, falsy values will be overwritten by the passed default. This is unwanted behavior in a number of cases.

For example, if I want to store a boolean value in local storage, which should default to `true`, but is set to `false`, then it will be overwritten. Instead, defaults should only be set if the local storage value doesn't exist (`undefined`).

Nice lib btw!