### PR TITLE
Fix linter issues for release

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -20,6 +20,7 @@ export type StorageProxy<TStorageDefinitions> = Partial<TStorageDefinitions> & {
   readonly [namespaceSymbol]: string;
   readonly [isStorageProxy]: true;
   readonly [storageTargetSymbol]: StorageTarget;
+  [storageProxyIntegrityKey]: string;
 };
 
 // --- Utilities ------------------------------------------------------------ //

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,7 @@
       "singleQuote": true,
       "trailingComma": "all",
       "bracketSpacing": true,
-      "jsxBracketSameLine": true
+      "jsxBracketSameLine": true,
       "variable-name": {
         "options": [
           "allow-leading-underscore"

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,11 @@
       "trailingComma": "all",
       "bracketSpacing": true,
       "jsxBracketSameLine": true
+      "variable-name": {
+        "options": [
+          "allow-leading-underscore"
+        ]
+      }
     }]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -10,11 +10,7 @@
       "trailingComma": "all",
       "bracketSpacing": true,
       "jsxBracketSameLine": true,
-      "variable-name": {
-        "options": [
-          "allow-leading-underscore"
-        ]
-      }
+      "variable-name": false,
     }]
   }
 }


### PR DESCRIPTION
Removes `variable-name` rule because it's causing issues I'm not interested in troubleshooting right now. It's a small library, nobody will be hurt by this.