### PR TITLE
Add 'isStorageAvailable' feature check

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,18 @@ myStorage.yolo     // Compiler error!
 
 For convenience, `StorageProxy` also provides several lightweight utilities for interacting with web storage.
 
-### `StorageProxy.verifyCache(storageProxy: StorageProxyObject, seed: string)`
+#### `StorageProxy.verifyCache(storageProxy: StorageProxyObject, seed: string)`
 
 Checks a cache key in the given `StorageProxyObject` and verifies whether the cache integrity is sound. This is handy for cache-busting `localStorage` and `sessionStorage`.
 
-### `StorageProxy.clearStorage(storageProxy: StorageProxyObject)`
+#### `StorageProxy.clearStorage(storageProxy: StorageProxyObject)`
 
 Clear the given web storage proxy object from `localStorage` or `sessionStorage`. Only keys under the namespace indicated by the `StorageProxyObject` are removed from the web storage caches.
 
-### `StorageProxy.restoreDefaults(storageProxy: StorageProxyObject)`
+#### `StorageProxy.restoreDefaults(storageProxy: StorageProxyObject)`
 
 Restores the default values given to `StorageProxy.createLocalStorage()` and `StorageProxy.createSessionStorage()`. However, unlike when the `StorageProxyObject` was initially created, this function privelages the default values _over_ what is currently in `WebStorage`.
 
-### `StorageProxy.isStorageAvailable(storageTarget?: StorageTarget)`
+#### `StorageProxy.isStorageAvailable(storageTarget?: StorageTarget)`
 
 Asserts whether the supplied `WebStorage` type is available. The `storageTarget` parameter defaults to `localStorage`. `StorageProxy` uses this utility internally to prevent raising errors in incompatible browser environments. This means you are protected from `WebStorage` permissions issues, but also counts as an important **gotcha!** It's crucial that your application works **with or without `WebStorage`**, so please try to _gracefully degrade functionality_ in such occurrences. This utility is exposed for that very purpose. Use it to your advantage!

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ const myLocalStorage = StorageProxy.createLocalStorage('my-namespace', {
   },
 });
 
-console.log(myLocalStorage.one.two.three)  // => "three"
-myLocalStorage.one.four.five = 'six';      // Works!
+console.log(myLocalStorage.one.two)    // => "three"
+myLocalStorage.one.four.five = 'six';  // Works!
 ```
 
 In TypeScript, you can define the shape of your stored data by passing a [generic type parameter](https://www.typescriptlang.org/docs/handbook/generics.html) to the factory function:
@@ -68,3 +68,23 @@ myStorage.foo      // Works!
 myStorage.bar.baz  // Works!
 myStorage.yolo     // Compiler error!
 ```
+
+## Utilities
+
+For convenience, `StorageProxy` also provides several lightweight utilities for interacting with web storage.
+
+### `StorageProxy.verifyCache(storageProxy: StorageProxyObject, seed: string)`
+
+Checks a cache key in the given `StorageProxyObject` and verifies whether the cache integrity is sound. This is handy for cache-busting `localStorage` and `sessionStorage`.
+
+### `StorageProxy.clearStorage(storageProxy: StorageProxyObject)`
+
+Clear the given web storage proxy object from `localStorage` or `sessionStorage`. Only keys under the namespace indicated by the `StorageProxyObject` are removed from the web storage caches.
+
+### `StorageProxy.restoreDefaults(storageProxy: StorageProxyObject)`
+
+Restores the default values given to `StorageProxy.createLocalStorage()` and `StorageProxy.createSessionStorage()`. However, unlike when the `StorageProxyObject` was initially created, this function privelages the default values _over_ what is currently in `WebStorage`.
+
+### `StorageProxy.isStorageAvailable(storageTarget?: StorageTarget)`
+
+Asserts whether the supplied `WebStorage` type is available. The `storageTarget` parameter defaults to `localStorage`. `StorageProxy` uses this utility internally to prevent raising errors in incompatible browser environments. This means you are protected from `WebStorage` permissions issues, but also counts as an important **gotcha!** It's crucial that your application works **with or without `WebStorage`**, so please try to _gracefully degrade functionality_ in such occurrences. This utility is exposed for that very purpose. Use it to your advantage!

--- a/src/index.umd.ts
+++ b/src/index.umd.ts
@@ -1,2 +1,2 @@
-import { StorageProxy } from './lib';
-export default StorageProxy;
+import { StorageProxyObject } from './lib';
+export default StorageProxyObject;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -236,14 +236,14 @@ export const StorageProxy = {
    * @returns `boolean` indicating whether the specified storage is available or not.
    */
   isStorageAvailable(storageTarget: StorageTarget = StorageTarget.Local) {
+    // Optimization: return the memoized value, if present.
+    if (isStorageAvailableCache.has(storageTarget)) return isStorageAvailableCache.get(storageTarget);
+
     // Disallow non-existant storage targets!
     if (storageTarget !== StorageTarget.Local && storageTarget !== StorageTarget.Session) {
       // tslint:disable-next-line:prettier
       throw new TypeError(`[storage-target] Expected \`WebStorage\` target to be one of: ('${StorageTarget.Local}', '${StorageTarget.Session}')`);
     }
-
-    // Optimization: return the memoized value, if present.
-    if (isStorageAvailableCache.has(storageTarget)) return isStorageAvailableCache.get(storageTarget);
 
     const storage = window[storageTarget];
 

--- a/test/src/storage-proxy.spec.ts
+++ b/test/src/storage-proxy.spec.ts
@@ -3,7 +3,7 @@
 import './mocks/browser';
 
 import { Expect, SetupFixture, Test, TestFixture } from 'alsatian';
-import { StorageProxy, StorageTarget } from '../../src/lib';
+import { StorageProxy, StorageProxyObject, StorageTarget } from '../../src/lib';
 
 // -------------------------------------------------------------------------- //
 
@@ -45,8 +45,8 @@ function getItem(storageTarget: StorageTarget, path: string) {
 
 @TestFixture('StorageProxy Tests')
 export class StorageProxyTestFixture {
-  lStore: StorageProxy<TestStorage>;
-  sStore: StorageProxy<TestStorage>;
+  lStore: StorageProxyObject<TestStorage>;
+  sStore: StorageProxyObject<TestStorage>;
 
   @SetupFixture
   public setupFixture() {


### PR DESCRIPTION
Improve usability by avoiding `WebStorage` permissions errors, adding a feature check before all instances of `WebStorage.getItem()` and `WebStorage.setItem`